### PR TITLE
build: add tag versions to docker

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*.*.*'
 
 permissions:
   contents: read
@@ -49,6 +51,9 @@ jobs:
             ${{ env.GHCR }}/${{ env.IMAGE_NAME }}
             ${{ env.DOCKERHUB_IMAGE }}
           tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,format=short
 


### PR DESCRIPTION
Add semantic versioning tags to Docker workflow to enable Renovate tracking                              

Changes                                                                                                  
- Trigger workflow on version tags (v*.*.*) in addition to main branch
- Add semver tag patterns to create 1.16.2, 1.16, and 1 tags from release tags
- Maintain existing latest tag on main branch and sha-XXXXXXX tags