### PR TITLE
Remove static TMDB mapping for tt37546380

### DIFF
--- a/src/config/imdbToTmdb.json
+++ b/src/config/imdbToTmdb.json
@@ -21,10 +21,5 @@
     "title": "Foodish",
     "note": "TMDB non ha l'IMDB ID linkato correttamente",
     "tmdb_id": "287309"
-  },
-  "tt37546380": {
-  "title": "Little Big Italy",
-  "note": "TMDB non ha l'IMDB ID linkato correttamente",
-  "tmdb_id": "154133"
   }
 }


### PR DESCRIPTION
## 🔗 Nuova normalizzazione

| Campo | Valore |
|-------|--------|
| **MAL English name** | <!-- AUTO --> |
| **AnimeSaturn name** | <!-- AUTO --> |

### Checklist
- [x] Compilazione corretta secondo Issue
- [x] I test esistenti passano
- [x] Non rompe altre normalizzazioni

_Questa PR è stata generata automaticamente dalla Issue #<!-- AUTO -->._

PR to fix: https://github.com/qwertyuiop8899/streamvix/issues/648

L'ID IMDB ora corrisponde su TMDB

<img width="533" height="136" alt="Screenshot 2026-04-10 alle 15 44 05" src="https://github.com/user-attachments/assets/c6675f1d-7543-443a-b33b-680a9a6cb0ab" />
