### PR TITLE
Added optional sub stream filtering configuration

### DIFF
--- a/src/addon.ts
+++ b/src/addon.ts
@@ -58,7 +58,6 @@ import { getDvrStreamsForChannel, getDvrConfig, buildDvrRecordEntry } from './ut
 const DISABLE_LIVE_EVENTS = process.env.DISABLE_LIVE_EVENTS === 'true';
 const IS_MH_DISABLED = (() => { try { const v = (process.env.DISABLE_MH || '').toLowerCase(); return v === 'true' || v === '1' || v === 'on'; } catch { return false; } })();
 const IS_SS_DISABLED = (() => { try { const v = (process.env.DISABLE_SPS || '').toLowerCase(); return v === 'true' || v === '1' || v === 'on'; } catch { return false; } })();
-const IS_SUB_DISABLED = (() => { try { const v = (process.env.DISABLE_SUB || '').toLowerCase(); return v === 'true' || v === '1' || v === 'on'; } catch { return false; } })();
 interface AddonConfig {
     tmdbApiKey?: string;
     mediaFlowProxyUrl?: string;
@@ -77,6 +76,7 @@ interface AddonConfig {
     loonexEnabled?: boolean;
     toonitaliaEnabled?: boolean;
     disableLiveTv?: boolean;
+    disableSub?: boolean;
     trailerEnabled?: boolean;
     disableVixsrc?: boolean;
     tvtapProxyEnabled?: boolean;
@@ -884,6 +884,7 @@ const baseManifest: Manifest = {
         { key: "vixDirectFhd", title: "SC: Synthetic FHD (solo installazione locale)", type: "checkbox" },
         { key: "vixProxy", title: "SC: Proxy (richiede Proxy, consigliato)", type: "checkbox" },
         { key: "disableLiveTv", title: "Live TV 📺 [Molti canali hanno bisogno di MFP]", type: "checkbox" },
+        { key: "disableSub", title: "Nascondi varianti SUB", type: "checkbox", default: false },
         { key: "trailerEnabled", title: "🎬▶️ Trailer", type: "checkbox", default: "checked" },
         { key: "animeunityEnabled", title: "Enable AnimeUnity", type: "checkbox" },
         { key: "animeunityDirect", title: "AnimeUnity Direct (solo installazione locale)", type: "checkbox" },
@@ -3184,11 +3185,12 @@ function createBuilder(initialConfig: AddonConfig = {}) {
                 console.log(`🔧 [MFP] User config: url=${mfpUrl || '(none)'} pass=${mfpPsw ? 'SET' : '(none)'} backend=${useMediaFlow ? 'MediaFlow' : 'EasyProxy'}`);
 
                 const allStreams: Stream[] = [];
+                const disableSubStreams = config.disableSub === true || config.disableSub === 'true' || config.disableSub === 'on' || config.disableSub === 1 || config.disableSub === '1';
                 const filterDisabledStreams = (streams: Stream[]): Stream[] => {
                     if (!streams.length) return streams;
 
                     let filtered = streams;
-                    if (IS_SUB_DISABLED) {
+                    if (disableSubStreams) {
                         filtered = filtered.filter(stream => {
                             const title = String(stream.title || '');
                             const name = String(stream.name || '');
@@ -6132,7 +6134,7 @@ function createBuilder(initialConfig: AddonConfig = {}) {
                     const cfg = config as any;
                     // Check if user has explicitly set any provider or flag
                     const providerKeys = [
-                        'trailerEnabled', 'disableVixsrc', 'vixDirect', 'vixDirectFhd', 'vixProxy',
+                        'trailerEnabled', 'disableSub', 'disableVixsrc', 'vixDirect', 'vixDirectFhd', 'vixProxy',
                         'guardahdEnabled', 'guardaserieEnabled', 'guardoserieEnabled', 'guardaflixEnabled',
                         'eurostreamingEnabled', 'loonexEnabled', 'toonitaliaEnabled', 'cb01Enabled',
                         'animesaturnEnabled', 'animeworldEnabled', 'animeunityEnabled'

--- a/src/addon.ts
+++ b/src/addon.ts
@@ -58,6 +58,7 @@ import { getDvrStreamsForChannel, getDvrConfig, buildDvrRecordEntry } from './ut
 const DISABLE_LIVE_EVENTS = process.env.DISABLE_LIVE_EVENTS === 'true';
 const IS_MH_DISABLED = (() => { try { const v = (process.env.DISABLE_MH || '').toLowerCase(); return v === 'true' || v === '1' || v === 'on'; } catch { return false; } })();
 const IS_SS_DISABLED = (() => { try { const v = (process.env.DISABLE_SPS || '').toLowerCase(); return v === 'true' || v === '1' || v === 'on'; } catch { return false; } })();
+const IS_SUB_DISABLED = (() => { try { const v = (process.env.DISABLE_SUB || '').toLowerCase(); return v === 'true' || v === '1' || v === 'on'; } catch { return false; } })();
 interface AddonConfig {
     tmdbApiKey?: string;
     mediaFlowProxyUrl?: string;
@@ -3183,6 +3184,22 @@ function createBuilder(initialConfig: AddonConfig = {}) {
                 console.log(`🔧 [MFP] User config: url=${mfpUrl || '(none)'} pass=${mfpPsw ? 'SET' : '(none)'} backend=${useMediaFlow ? 'MediaFlow' : 'EasyProxy'}`);
 
                 const allStreams: Stream[] = [];
+                const filterDisabledStreams = (streams: Stream[]): Stream[] => {
+                    if (!streams.length) return streams;
+
+                    let filtered = streams;
+                    if (IS_SUB_DISABLED) {
+                        filtered = filtered.filter(stream => {
+                            const title = String(stream.title || '');
+                            const name = String(stream.name || '');
+                            const bingeGroup = String(stream.behaviorHints?.bingeGroup || '');
+                            return !/(^|\n)\s*🗣\s*\[SUB\]/i.test(title)
+                                && !/\[SUB(?:\s*ITA)?\]/i.test(`${title}\n${name}`)
+                                && !/(^|-)sub($|-)/i.test(bingeGroup);
+                        });
+                    }
+                    return filtered;
+                };
 
                 // === DVR STREAM HANDLER ===
                 // Handle DVR recording playback (IDs starting with dvr:)
@@ -6945,8 +6962,9 @@ function createBuilder(initialConfig: AddonConfig = {}) {
                     }
                 }
 
-                console.log(`✅ Total streams returned: ${allStreams.length}`);
-                return { streams: allStreams };
+                const result = { streams: filterDisabledStreams(allStreams) };
+                console.log(`✅ Total streams returned: ${result.streams.length}`);
+                return result;
             } catch (error) {
                 console.error('Stream extraction failed:', error);
                 return { streams: [] };

--- a/src/landingPage.ts
+++ b/src/landingPage.ts
@@ -497,6 +497,7 @@ function landingTemplate(manifest: any) {
 				const toggleMap: any = {
 					'disableVixsrc': { title: 'StreamingCommunity 🍿', invert: true },
 					'disableLiveTv': { title: 'Live TV 📺 <span style="font-size:0.65rem; opacity:0.75; font-weight:600;">(Molti canali hanno bisogno di MFP)</span>', invert: true },
+					'disableSub': { title: 'Nascondi varianti SUB', invert: false },
 					'trailerEnabled': { title: '🎬▶️ Trailer TMDB', invert: false },
 					'animeunityEnabled': { title: 'Anime Unity ⛩️ - 🔓 🔒 <span style="font-size:0.65rem; opacity:0.75; font-weight:600;">(Alcuni flussi hanno bisogno di MFP)</span>', invert: false },
 					'animesaturnEnabled': { title: 'Anime Saturn 🪐 - 🔓 🔒 <span style="font-size:0.65rem; opacity:0.75; font-weight:600;">(Alcuni flussi hanno bisogno di MFP)</span>', invert: false },
@@ -1134,6 +1135,7 @@ function landingTemplate(manifest: any) {
 					var orderIds = [
 						'disableLiveTv',        // Live TV first
 						'trailerEnabled',       // Trailer TMDB right after Live TV
+						'disableSub',           // Hide SUB variants
 						'disableVixsrc',         // VixSrc directly under Live TV block
 						'cb01Enabled',           // CB01
 						'guardahdEnabled',       // GuardaHD


### PR DESCRIPTION
This PR introduces an optional configuration to filter out sub streams.

Use case: some users prefer not to see sub streams in the available stream list (e.g. to reduce clutter or avoid selecting subbed content by mistake).

When enabled, the system will exclude sub streams based on the provided configuration, while keeping the default behavior unchanged if the option is not set or disabled.