### PR TITLE
feat(logging): gate per-request hot-path logs behind DEBUG_LOG

### DIFF
--- a/src/addon.ts
+++ b/src/addon.ts
@@ -1752,12 +1752,9 @@ function createBuilder(initialConfig: AddonConfig = {}) {
             } catch { }
             try {
                 const lastReq0: any = (global as any).lastExpressRequest;
-                console.log('📥 Catalog TV request:', {
-                    id,
-                    extra,
-                    path: lastReq0?.path,
-                    url: lastReq0?.url
-                });
+                // Gated behind DEBUG_LOG: fires on every catalog request from
+                // every connected Stremio client (~once per minute per user).
+                debugLog('📥 Catalog TV request:', { id, extra, path: lastReq0?.path, url: lastReq0?.url });
             } catch { }
             // === Catalogo TV: cache in memoria (default ON) ===
             // La cache e' GLOBALE per processo: condivisa tra tutti gli utenti dello stesso pod.
@@ -2360,7 +2357,8 @@ function createBuilder(initialConfig: AddonConfig = {}) {
                 return channelWithPrefix;
             }));
 
-            console.log(`✅ Returning ${tvChannelsWithPrefix.length} TV channels for catalog ${id}${isPlaceholder ? ' (placeholder, cacheMaxAge=0)' : ''}`);
+            // Gated behind DEBUG_LOG (per-request).
+            debugLog(`✅ Returning ${tvChannelsWithPrefix.length} TV channels for catalog ${id}${isPlaceholder ? ' (placeholder, cacheMaxAge=0)' : ''}`);
             return isPlaceholder
                 ? { metas: tvChannelsWithPrefix, cacheMaxAge: 0 }
                 : { metas: tvChannelsWithPrefix, cacheMaxAge: 3600 };
@@ -2378,12 +2376,13 @@ function createBuilder(initialConfig: AddonConfig = {}) {
 
     // === HANDLER META ===
     builder.defineMetaHandler(async ({ type, id, config: requestConfig }: { type: string; id: string; config?: any }) => {
-        console.log(`📺 META REQUEST: type=${type}, id=${id}`);
+        // Gated behind DEBUG_LOG (per-request).
+        debugLog(`📺 META REQUEST: type=${type}, id=${id}`);
         if (type === "tv") {
             // Server-side cache check (user-independent, EPG-enriched)
             const cached = tvMetaCache.get(id);
             if (cached && (Date.now() - cached.ts) < TV_META_CACHE_TTL) {
-                console.log(`⚡ META CACHE HIT: ${id}`);
+                debugLog(`⚡ META CACHE HIT: ${id}`);
                 return cached.data;
             }
 
@@ -2869,7 +2868,8 @@ function createBuilder(initialConfig: AddonConfig = {}) {
                 // Use normalized type for all downstream logic
                 type = normalizedType;
 
-                console.log(`🔍 Stream request: ${normalizedType}/${id}`);
+                // Gated behind DEBUG_LOG (per-request).
+                debugLog(`🔍 Stream request: ${normalizedType}/${id}`);
 
                 // Runtime disable live TV — blocca TUTTI gli stream TV (SportZX, Sports99, MediaHosting, Freeshot, ThisNot, canali statici)
                 // FIX: usa config dell'utente (requestConfig) con fallback a configCache globale


### PR DESCRIPTION
> Part of a coordinated 9-PR series from the [elfhosted](https://elfhosted.com) ops team. See #704 for the series intro.

## Problem

The catalog/meta/stream handlers each emit a `console.log` on every request:

- `📥 Catalog TV request: { ... }`
- `📺 META REQUEST: type=..., id=...`
- `⚡ META CACHE HIT: ...`
- `🔍 Stream request: ...`
- `✅ Returning N TV channels for catalog ...`

With sustained traffic these add up to hundreds of log lines per second per pod, all going through JSON serialization + stdout writes.

## Fix

`debugLog()` is already defined and gated by the `DEBUG_LOG` env var (default off). This patch replaces the raw `console.log` calls on the per-request hot paths with `debugLog`. Production stays quiet unless the operator opts in with `DEBUG_LOG=1` for diagnosis.

No behavior change with `DEBUG_LOG=1`; output is unchanged in dev. Pure stdout / CPU reduction in prod.

Error logs (`console.error`) and startup logs are intentionally left alone — only the per-request ones are gated.

## Files

- `src/addon.ts` — 5 `console.log` → `debugLog` replacements.