### PR TITLE
feat: add /admin/cpu-stats endpoint for live diagnostics

### DIFF
--- a/src/addon.ts
+++ b/src/addon.ts
@@ -1697,6 +1697,32 @@ function normalizeProxyUrl(url: string): string {
     return url.endsWith('/') ? url.slice(0, -1) : url;
 }
 
+// Lightweight in-process counters exposed via /admin/cpu-stats. Every
+// increment is wrapped in try/catch so it cannot break a request if
+// anything goes wrong with the counters themselves.
+interface AddonStats {
+    bootMs: number;
+    catalogRequests: number;
+    metaRequests: number;
+    metaCacheHits: number;
+    streamRequests: number;
+    epgFindCalls: number;
+    epgFindHits: number;
+    epgFindMisses: number;
+    epgFindTotalNs: bigint;
+}
+const _addonStats: AddonStats = {
+    bootMs: Date.now(),
+    catalogRequests: 0,
+    metaRequests: 0,
+    metaCacheHits: 0,
+    streamRequests: 0,
+    epgFindCalls: 0,
+    epgFindHits: 0,
+    epgFindMisses: 0,
+    epgFindTotalNs: 0n,
+};
+
 // Funzione per creare il builder con configurazione dinamica
 function createBuilder(initialConfig: AddonConfig = {}) {
     const manifest = loadCustomConfig();
@@ -1752,6 +1778,7 @@ function createBuilder(initialConfig: AddonConfig = {}) {
             } catch { }
             try {
                 const lastReq0: any = (global as any).lastExpressRequest;
+                try { _addonStats.catalogRequests++; } catch { /* ignore */ }
                 console.log('📥 Catalog TV request:', {
                     id,
                     extra,
@@ -2335,7 +2362,15 @@ function createBuilder(initialConfig: AddonConfig = {}) {
                     // Canali tradizionali: EPG
                     try {
                         const epgChannelIds = (channel as any).epgChannelIds;
+                        const _epgFindStartNs: bigint = process.hrtime.bigint();
                         const epgChannelId = epgManager.findEPGChannelId(channel.name, epgChannelIds);
+                        try {
+                            _addonStats.epgFindCalls++;
+                            const _elapsedNs: bigint = process.hrtime.bigint() - _epgFindStartNs;
+                            _addonStats.epgFindTotalNs = _addonStats.epgFindTotalNs + _elapsedNs;
+                            if (epgChannelId) _addonStats.epgFindHits++;
+                            else _addonStats.epgFindMisses++;
+                        } catch { /* ignore */ }
                         if (epgChannelId) {
                             const currentProgram = await epgManager.getCurrentProgram(epgChannelId);
                             if (currentProgram) {
@@ -2379,11 +2414,13 @@ function createBuilder(initialConfig: AddonConfig = {}) {
     // === HANDLER META ===
     builder.defineMetaHandler(async ({ type, id, config: requestConfig }: { type: string; id: string; config?: any }) => {
         console.log(`📺 META REQUEST: type=${type}, id=${id}`);
+        try { _addonStats.metaRequests++; } catch { /* ignore */ }
         if (type === "tv") {
             // Server-side cache check (user-independent, EPG-enriched)
             const cached = tvMetaCache.get(id);
             if (cached && (Date.now() - cached.ts) < TV_META_CACHE_TTL) {
                 console.log(`⚡ META CACHE HIT: ${id}`);
+                try { _addonStats.metaCacheHits++; } catch { /* ignore */ }
                 return cached.data;
             }
 
@@ -2784,7 +2821,15 @@ function createBuilder(initialConfig: AddonConfig = {}) {
                     // Meta: canali tradizionali con EPG
                     try {
                         const epgChannelIds = (channel as any).epgChannelIds;
+                        const _epgFindStartNs: bigint = process.hrtime.bigint();
                         const epgChannelId = epgManager.findEPGChannelId(channel.name, epgChannelIds);
+                        try {
+                            _addonStats.epgFindCalls++;
+                            const _elapsedNs: bigint = process.hrtime.bigint() - _epgFindStartNs;
+                            _addonStats.epgFindTotalNs = _addonStats.epgFindTotalNs + _elapsedNs;
+                            if (epgChannelId) _addonStats.epgFindHits++;
+                            else _addonStats.epgFindMisses++;
+                        } catch { /* ignore */ }
                         if (epgChannelId) {
                             const currentProgram = await epgManager.getCurrentProgram(epgChannelId);
                             const nextProgram = await epgManager.getNextProgram(epgChannelId);
@@ -2870,6 +2915,7 @@ function createBuilder(initialConfig: AddonConfig = {}) {
                 type = normalizedType;
 
                 console.log(`🔍 Stream request: ${normalizedType}/${id}`);
+                try { _addonStats.streamRequests++; } catch { /* ignore */ }
 
                 // Runtime disable live TV — blocca TUTTI gli stream TV (SportZX, Sports99, MediaHosting, Freeshot, ThisNot, canali statici)
                 // FIX: usa config dell'utente (requestConfig) con fallback a configCache globale
@@ -8507,6 +8553,94 @@ app.get('/live/purge', (req: Request, res: Response) => {
     }
 });
 // =============================================================
+// ================================================================
+
+// ================= /admin/cpu-stats =============================
+// Read-only in-process counters: request rates, EPG-find timing,
+// memory usage, uptime, cache state. Useful for live debugging of
+// CPU/memory issues without a heap snapshot or profile.
+//
+// Auth: optional. If ADMIN_TOKEN env is set, require ?token=... or
+// X-Admin-Token header. If unset, the endpoint is readable.
+function _addonAdminAuth(req: Request, res: Response, requireToken: boolean): boolean {
+    const tok = (process.env.ADMIN_TOKEN || '').trim();
+    if (!tok) {
+        if (requireToken) {
+            res.status(403).json({ ok: false, error: 'ADMIN_TOKEN not configured on this pod' });
+            return false;
+        }
+        return true;
+    }
+    const provided = ((req.query.token as string) || req.headers['x-admin-token'] || '').toString();
+    if (provided !== tok) {
+        res.status(403).json({ ok: false, error: 'Forbidden' });
+        return false;
+    }
+    return true;
+}
+app.get('/admin/cpu-stats', (req: Request, res: Response) => {
+    if (!_addonAdminAuth(req, res, false)) return;
+    try {
+        const mem = process.memoryUsage();
+        const upMs = Date.now() - _addonStats.bootMs;
+        const epgFindCalls = _addonStats.epgFindCalls;
+        const epgFindAvgUs = epgFindCalls > 0
+            ? Number(_addonStats.epgFindTotalNs / BigInt(epgFindCalls)) / 1000
+            : 0;
+        const metaHitRate = _addonStats.metaRequests > 0
+            ? (_addonStats.metaCacheHits / _addonStats.metaRequests)
+            : null;
+        const g: any = global as any;
+        res.json({
+            ok: true,
+            uptimeMs: upMs,
+            uptimeHumanS: Math.round(upMs / 1000),
+            memory: {
+                rssMb: +(mem.rss / 1024 / 1024).toFixed(1),
+                heapUsedMb: +(mem.heapUsed / 1024 / 1024).toFixed(1),
+                heapTotalMb: +(mem.heapTotal / 1024 / 1024).toFixed(1),
+                externalMb: +(mem.external / 1024 / 1024).toFixed(1),
+                arrayBuffersMb: +(mem.arrayBuffers / 1024 / 1024).toFixed(1),
+            },
+            catalog: {
+                requests: _addonStats.catalogRequests,
+                cacheKey: g.__tvCatalogCache?.key || null,
+                cacheBuiltAgeMs: g.__tvCatalogCache?.builtMs ? (Date.now() - g.__tvCatalogCache.builtMs) : null,
+                cacheSize: Array.isArray(g.__tvCatalogCache?.channels) ? g.__tvCatalogCache.channels.length : 0,
+            },
+            meta: {
+                requests: _addonStats.metaRequests,
+                cacheHits: _addonStats.metaCacheHits,
+                cacheHitRate: metaHitRate,
+            },
+            stream: {
+                requests: _addonStats.streamRequests,
+            },
+            epg: {
+                findCalls: epgFindCalls,
+                hits: _addonStats.epgFindHits,
+                misses: _addonStats.epgFindMisses,
+                avgUs: +epgFindAvgUs.toFixed(2),
+                totalMs: +(Number(_addonStats.epgFindTotalNs) / 1e6).toFixed(1),
+            },
+        });
+    } catch (e: any) {
+        res.status(500).json({ ok: false, error: e?.message || String(e) });
+    }
+});
+app.get('/admin/cpu-stats/reset', (req: Request, res: Response) => {
+    if (!_addonAdminAuth(req, res, true)) return;
+    _addonStats.bootMs = Date.now();
+    _addonStats.catalogRequests = 0;
+    _addonStats.metaRequests = 0;
+    _addonStats.metaCacheHits = 0;
+    _addonStats.streamRequests = 0;
+    _addonStats.epgFindCalls = 0;
+    _addonStats.epgFindHits = 0;
+    _addonStats.epgFindMisses = 0;
+    _addonStats.epgFindTotalNs = 0n;
+    res.json({ ok: true, resetAt: new Date().toISOString() });
+});
 // ================================================================
 
 // ================= RUNTIME TOGGLE FAST/EXTRACTOR ================


### PR DESCRIPTION
> Part of a coordinated 9-PR series from the [elfhosted](https://elfhosted.com) ops team. See #704 for the series intro.

## What

Adds in-process counters and a `/admin/cpu-stats` JSON endpoint that returns them. Useful for diagnosing CPU and memory issues on a live deployment without attaching a profiler.

Counters tracked:
- Catalog / meta / stream request counts
- Meta cache hit rate
- EPG-find call count, average µs, total time
- Process memory (RSS, heapUsed, heapTotal, external, arrayBuffers)
- Process uptime

Counters are incremented at the top of each handler. Every increment is wrapped in try/catch so a counter bug cannot break a request.

## Endpoint auth

- If `ADMIN_TOKEN` env var is set: require `?token=<value>` or `X-Admin-Token` header.
- If unset: the endpoint is readable without a token (it only exposes counters / memory / uptime — no secrets).
- The `/admin/cpu-stats/reset` endpoint **always** requires a token.

## Sample response

```json
{
  "ok": true,
  "uptimeMs": 235000,
  "memory": { "rssMb": 237.9, "heapUsedMb": 77.8, "...": "..." },
  "catalog": { "requests": 11, "cacheSize": 826 },
  "meta": { "requests": 133, "cacheHits": 21, "cacheHitRate": 0.158 },
  "stream": { "requests": 175 },
  "epg": { "findCalls": 38, "hits": 36, "avgUs": 89.31, "totalMs": 3.4 }
}
```

Zero behavior change otherwise — just observability.

## Files

- `src/addon.ts` — added `AddonStats` interface, `_addonStats` instance, counter increments at hot-path entry points, `/admin/cpu-stats` + `/admin/cpu-stats/reset` endpoints.