### PR TITLE
feat: add /admin/cpu-profile + /admin/heap-snapshot endpoints

### DIFF
--- a/src/addon.ts
+++ b/src/addon.ts
@@ -8509,6 +8509,148 @@ app.get('/live/purge', (req: Request, res: Response) => {
 // =============================================================
 // ================================================================
 
+// ================= /admin/cpu-profile, /admin/heap-snapshot =====
+// Live profiling endpoints for diagnosing CPU/memory issues without a
+// pod restart. Always require ADMIN_TOKEN — these are heavyweight and
+// can affect a live deployment.
+//
+// /admin/cpu-profile/start?durationMs=N — begins a V8 CPU profile
+// /admin/cpu-profile/stop                — stops + streams .cpuprofile
+// /admin/heap-snapshot                   — writes .heapsnapshot to /tmp
+//
+// Multi-replica note: profile session state lives in pod memory, so
+// the start and stop must hit the SAME pod. Use sessionAffinity:
+// ClientIP on the Service or scale to one replica before profiling.
+function _addonAdminAuthRequire(req: Request, res: Response): boolean {
+    const tok = (process.env.ADMIN_TOKEN || '').trim();
+    if (!tok) {
+        res.status(403).json({ ok: false, error: 'ADMIN_TOKEN not configured on this pod' });
+        return false;
+    }
+    const provided = ((req.query.token as string) || req.headers['x-admin-token'] || '').toString();
+    if (provided !== tok) {
+        res.status(403).json({ ok: false, error: 'Forbidden' });
+        return false;
+    }
+    return true;
+}
+let _addonProfilerSession: any = null;
+let _addonProfilerStartedAt: number = 0;
+app.get('/admin/cpu-profile/start', async (req: Request, res: Response) => {
+    if (!_addonAdminAuthRequire(req, res)) return;
+    if (_addonProfilerSession) {
+        res.status(409).json({ ok: false, error: 'profile already running', startedAt: _addonProfilerStartedAt });
+        return;
+    }
+    try {
+        const inspector = require('node:inspector') || require('inspector');
+        const session = new inspector.Session();
+        session.connect();
+        await new Promise<void>((resolve, reject) => {
+            session.post('Profiler.enable', (err: any) => err ? reject(err) : resolve());
+        });
+        await new Promise<void>((resolve, reject) => {
+            session.post('Profiler.start', (err: any) => err ? reject(err) : resolve());
+        });
+        _addonProfilerSession = session;
+        _addonProfilerStartedAt = Date.now();
+        const durationMs = Math.max(1000, Math.min(600000, parseInt((req.query.durationMs as string) || '30000', 10)));
+        // Auto-stop after duration so a forgotten profile doesn't run forever.
+        setTimeout(() => {
+            if (_addonProfilerSession) {
+                _addonProfilerSession.post('Profiler.stop', () => {
+                    try { _addonProfilerSession.disconnect(); } catch { /* ignore */ }
+                    _addonProfilerSession = null;
+                    console.log('[admin] CPU profile auto-stopped after timeout');
+                });
+            }
+        }, durationMs + 60000);
+        res.json({ ok: true, startedAt: _addonProfilerStartedAt, autoStopAfterMs: durationMs + 60000 });
+    } catch (e: any) {
+        res.status(500).json({ ok: false, error: e?.message || String(e) });
+    }
+});
+app.get('/admin/cpu-profile/stop', async (req: Request, res: Response) => {
+    if (!_addonAdminAuthRequire(req, res)) return;
+    if (!_addonProfilerSession) {
+        res.status(409).json({ ok: false, error: 'no profile running' });
+        return;
+    }
+    try {
+        const profileResult: any = await new Promise((resolve, reject) => {
+            _addonProfilerSession.post('Profiler.stop', (err: any, result: any) => err ? reject(err) : resolve(result));
+        });
+        try { _addonProfilerSession.disconnect(); } catch { /* ignore */ }
+        _addonProfilerSession = null;
+        const durationMs = Date.now() - _addonProfilerStartedAt;
+        _addonProfilerStartedAt = 0;
+        res.setHeader('Content-Type', 'application/json');
+        res.setHeader('Content-Disposition', `attachment; filename="streamvix-${Date.now()}.cpuprofile"`);
+        res.send(JSON.stringify({ ...profileResult.profile, _meta: { durationMs } }));
+    } catch (e: any) {
+        res.status(500).json({ ok: false, error: e?.message || String(e) });
+    }
+});
+app.get('/admin/heap-snapshot', async (req: Request, res: Response) => {
+    if (!_addonAdminAuthRequire(req, res)) return;
+    try {
+        // v8.getHeapSnapshot() blocks the event loop AND requires ~2x the
+        // current heap as working memory for serialization. Calling it when
+        // the pod is near its memory limit will OOM the pod. Refuse unless
+        // we have headroom — or the caller passes ?force=1.
+        const force = String(req.query.force || '') === '1';
+        const mem = process.memoryUsage();
+        const heapNeededBytes = Math.ceil(mem.heapUsed * 2.5);
+        let memLimitBytes = 0;
+        try {
+            // cgroups v2
+            const raw = fs.readFileSync('/sys/fs/cgroup/memory.max', 'utf8').trim();
+            if (raw && raw !== 'max') memLimitBytes = parseInt(raw, 10) || 0;
+        } catch { /* try v1 */ }
+        if (!memLimitBytes) {
+            try {
+                const raw = fs.readFileSync('/sys/fs/cgroup/memory/memory.limit_in_bytes', 'utf8').trim();
+                memLimitBytes = parseInt(raw, 10) || 0;
+                // Many containers report a huge sentinel value when unlimited;
+                // treat anything > 64 GiB as "unknown".
+                if (memLimitBytes > 64 * 1024 * 1024 * 1024) memLimitBytes = 0;
+            } catch { /* still unknown */ }
+        }
+        const effectiveLimit = memLimitBytes || (800 * 1024 * 1024);
+        const headroom = effectiveLimit - mem.rss;
+        if (!force && headroom < heapNeededBytes) {
+            res.status(409).json({
+                ok: false,
+                error: 'insufficient memory headroom; would likely OOM the pod',
+                memory: {
+                    rssMb: +(mem.rss / 1024 / 1024).toFixed(1),
+                    heapUsedMb: +(mem.heapUsed / 1024 / 1024).toFixed(1),
+                    needHeadroomMb: +(heapNeededBytes / 1024 / 1024).toFixed(1),
+                    headroomMb: +(headroom / 1024 / 1024).toFixed(1),
+                    limitMb: +(effectiveLimit / 1024 / 1024).toFixed(1),
+                    limitSource: memLimitBytes ? 'cgroups' : 'fallback-800Mi',
+                },
+                hint: 'pass ?force=1 to override (risk: OOMKill), or restart the pod to take a snapshot at low memory',
+            });
+            return;
+        }
+        const v8 = require('v8');
+        const outPath = `/tmp/streamvix-${Date.now()}.heapsnapshot`;
+        const stream = v8.getHeapSnapshot();
+        const ws = fs.createWriteStream(outPath);
+        stream.pipe(ws);
+        await new Promise<void>((resolve, reject) => {
+            ws.on('finish', () => resolve());
+            ws.on('error', (e: any) => reject(e));
+        });
+        const st = fs.statSync(outPath);
+        res.json({ ok: true, path: outPath, sizeMb: +(st.size / 1024 / 1024).toFixed(1) });
+    } catch (e: any) {
+        res.status(500).json({ ok: false, error: e?.message || String(e) });
+    }
+});
+// ================================================================
+
 // ================= RUNTIME TOGGLE FAST/EXTRACTOR ================
 // /admin/mode?fast=1 abilita fast mode (diretto); ?fast=0 torna extractor
 // Restituisce lo stato corrente. Non persiste su restart (solo runtime)


### PR DESCRIPTION
> Part of a coordinated 9-PR series from the [elfhosted](https://elfhosted.com) ops team. See #704 for the series intro.

## What

Live profiling endpoints for diagnosing CPU and memory issues on a running pod without attaching a debugger or restarting:

- `GET /admin/cpu-profile/start?durationMs=N` — begin a V8 inspector CPU profile. Auto-stops after `durationMs + 60s` if not stopped manually.
- `GET /admin/cpu-profile/stop` — stop the profile and stream the result as a `.cpuprofile` JSON download. Load in Chrome DevTools → Performance → Load profile.
- `GET /admin/heap-snapshot` — write a `.heapsnapshot` to `/tmp` and return the path. Use `kubectl cp` to pull it out, then load in Chrome DevTools → Memory.

## Auth

`ADMIN_TOKEN` env var is **REQUIRED** (no fallback for these — they're heavyweight and can affect a live deployment). Pass via `?token=...` or `X-Admin-Token` header.

## Safety: heap-snapshot OOM guard

`v8.getHeapSnapshot()` blocks the event loop AND requires ~2× the current heap as working memory for serialization. We learned this the hard way — calling it on a memory-pressured pod will OOM the pod.

The endpoint includes a check: refuses with HTTP 409 if `heapUsed × 2.5 > available memory headroom`. Reads cgroups v1 or v2 limit (falls back to 800 MiB if neither is readable). Pass `?force=1` to override.

Example refused response:
```json
{
  "ok": false,
  "error": "insufficient memory headroom; would likely OOM the pod",
  "memory": { "rssMb": 599.5, "heapUsedMb": 398.1, "needHeadroomMb": 995.3, "headroomMb": 200.5, "limitMb": 800.0 },
  "hint": "pass ?force=1 to override (risk: OOMKill), or restart the pod to take a snapshot at low memory"
}
```

## Multi-replica note

The CPU profile session lives in pod memory, so the start and stop calls **must hit the same pod**. Add `sessionAffinity: ClientIP` to the Service, or scale to one replica before profiling.

## Files

- `src/addon.ts` — added `_addonAdminAuthRequire`, profile session state, three new endpoints next to the existing `/admin/mode` toggle.