### PR TITLE
fix(animeworld): il fallback serviva la versione giapponese etichettata ITA

### DIFF
--- a/src/providers/animeworld-provider.ts
+++ b/src/providers/animeworld-provider.ts
@@ -1523,10 +1523,21 @@ export class AnimeWorldProvider {
         console.log('[AnimeWorld][FallbackFilter] No results from filter year search');
         return { streams: [] };
       }
-      // Prendi massimo due risultati (ordine naturale) per imitare i/0 Original i/1 Italian
-      const picked = results.slice(0,2);
+      // Il vecchio codice prendeva results[0] e results[1] etichettandoli per posizione
+      // (0 = Original, 1 = Italian): con due SUB in cima serviva un SUB spacciato per ITA,
+      // spesso pure di un'altra parte della stagione. Ora la lingua viene dallo slug.
+      // I candidati restano ancorati allo slug base del primo risultato, altrimenti senza
+      // versione ITA si pescherebbe lo slug -ita di un anime completamente diverso.
+      const anchor = animeWorldSlugBase(results[0].slug || results[0].id || results[0].name);
+      const related = anchor
+        ? results.filter(r => animeWorldSlugBase(r.slug || r.id || r.name).startsWith(anchor))
+        : results;
+      console.log('[AnimeWorld][FallbackFilter] Anchor base:', anchor, 'correlati:', related.length, '/', results.length);
+      const picked = [
+        ...related.filter(r => isItaSlug(r.slug || r.id || r.name)).slice(0, 1),
+        ...related.filter(r => !isItaSlug(r.slug || r.id || r.name)).slice(0, 1),
+      ];
       const streams: StreamForStremio[] = [];
-      let idx = 0;
       for (const r of picked) {
         const slug = r.slug || r.id || r.name;
         if (!slug) continue;
@@ -1548,7 +1559,7 @@ export class AnimeWorldProvider {
           }
           const mp4 = streamData?.mp4_url;
           if (!mp4) continue;
-          const lang = idx === 0 ? 'Original' : 'Italian';
+          const lang = isItaSlug(slug) ? 'Italian' : 'Original';
           const sNum = seasonNumber || 1;
           let baseName = (r.name || slug || normalizedTitle).toString().trim();
           if (baseName.includes('\n')) baseName = baseName.replace(/\s+/g,' ').trim();
@@ -1556,7 +1567,6 @@ export class AnimeWorldProvider {
           if (episodeNumber) titleStream += `E${episodeNumber}`;
           const streamOut = buildAnimeWorldStreamOutput(mp4, slug, this.config, { bingeGroup: 'animeworld-fallback' });
           streams.push({ title: titleStream, url: streamOut.url, behaviorHints: streamOut.behaviorHints });
-          idx++;
         } catch (e) {
           console.warn('[AnimeWorld][FallbackFilter] error processing slug', r.slug, e);
         }
@@ -1568,6 +1578,21 @@ export class AnimeWorldProvider {
       return { streams: [] };
     }
   }
+}
+
+/** AnimeWorld marca il doppiaggio italiano col suffisso -ita / -cr-ita / -ita-cr sullo slug base. */
+export function isItaSlug(slugOrName: string): boolean {
+  const base = String(slugOrName || '').split('.')[0].toLowerCase();
+  if (/(?:^|[-_])sub[-_]?ita$/.test(base)) return false;
+  return /(?:^|[-_])(?:ita|cr[-_]?ita|ita[-_]?cr)$/.test(base);
+}
+
+/** Slug senza id random finale e senza suffisso di lingua: identifica l'opera, non la versione. */
+export function animeWorldSlugBase(slugOrName: string): string {
+  return String(slugOrName || '')
+    .split('.')[0]
+    .toLowerCase()
+    .replace(/(?:^|[-_])(?:sub[-_]?ita|cr[-_]?ita|ita[-_]?cr|ita)$/, '');
 }
 
 function capitalize(str: string) {

--- a/src/providers/animeworld-provider.ts
+++ b/src/providers/animeworld-provider.ts
@@ -1043,10 +1043,10 @@ export class AnimeWorldProvider {
       const slugBase = slug.split('.')[0] || '';
       if (/[-_]ita$/i.test(slugBase)) langLabel = 'ITA';
     }
-    const sNum = seasonNumber || 1;
     const epNum = isMovie ? Number(target.number || 1) : requestedEpisode;
-    let titleStream = `${capitalize(cleanName || titleFallback)} ▪ ${langLabel} ▪ S${sNum}`;
-    if (!isMovie && epNum) titleStream += `E${epNum}`;
+    let titleStream = `${capitalize(cleanName || titleFallback)} ▪ ${langLabel}`;
+    const epTag = isMovie ? '' : episodeTag(seasonNumber, epNum ?? null);
+    if (epTag) titleStream += ` ▪ ${epTag}`;
 
     const streamOut = buildAnimeWorldStreamOutput(mp4, slug, this.config);
     return [{ title: titleStream, url: streamOut.url, behaviorHints: streamOut.behaviorHints }];
@@ -1154,7 +1154,7 @@ export class AnimeWorldProvider {
       }
       // Try mapping API first — no expensive title resolution yet
       const fromMapping = await this.getStreamsFromMapping(
-        `kitsu:${kitsuId}`, seasonNumber, episodeNumber, isMovie, { kitsuId }, quickTitle
+        `kitsu:${kitsuId}`, null, episodeNumber, isMovie, { kitsuId }, quickTitle
       );
       if (fromMapping.length) {
         console.log('[AnimeWorld] Mapping hit (Kitsu): skipped heavy title resolution.');
@@ -1163,7 +1163,9 @@ export class AnimeWorldProvider {
       // Mapping miss → now do full title resolution for the title search fallback
       console.log('[AnimeWorld] Mapping miss (Kitsu): resolving full English title...');
       const englishTitle = await getEnglishTitleFromAnyId(kitsuId, 'kitsu', this.config.tmdbApiKey);
-      return this.handleTitleRequest(englishTitle, seasonNumber, episodeNumber, isMovie);
+      // seasonNumber qui vale sempre 1 (su Kitsu ogni stagione e' un anime separato): non e'
+      // la stagione dell'opera, quindi non va usato per l'etichetta.
+      return this.handleTitleRequest(englishTitle, null, episodeNumber, isMovie);
     } catch (e) {
       console.error('[AnimeWorld] kitsu handler error', e);
       return { streams: [] };
@@ -1454,38 +1456,16 @@ export class AnimeWorldProvider {
         if (seen.has(finalUrl)) return null;
         seen.add(finalUrl);
 
-        let cleanName = v.name.replace(/\r?\n+/g, ' ').replace(/\s{2,}/g, ' ').trim();
-        cleanName = cleanName
-          .replace(/\bDUB\b/gi, '')
-          .replace(/\(ITA\)/gi, '')
-          .replace(/\(CR\)/gi, '')
-          .replace(/CR/gi, '')
-          .replace(/ITA/gi, '')
-          .replace(/Movie/gi, '')
-          .replace(/Special/gi, '')
-          .replace(/\s{2,}/g, ' ')
-          .trim();
+        const baseName = animeWorldDisplayName(v.name, v.slug, normalized || title);
 
-        let baseName = cleanName;
-        const looksLikeLangOnly = /^[A-Z]{2,4}$/i.test(baseName || '');
-        if (!baseName || baseName.length < 3 || looksLikeLangOnly) {
-          const slugBase = ((v.slug || '') as string).toLowerCase().split('.')[0];
-          let fromSlug = slugBase
-            .replace(/(?:^|[-_])(sub[-_]?ita|cr[-_]?ita|ita[-_]?cr|ita)(?:$|[-_])/gi, ' ')
-            .replace(/[^a-z0-9]+/gi, ' ')
-            .trim();
-          if (!fromSlug) fromSlug = (normalized || title || '').toString();
-          baseName = fromSlug;
-        }
-
-        const sNum = seasonNumber || 1;
         let langLabel = 'SUB';
         if (v.language_type === 'ITA') langLabel = 'ITA';
         else if (v.language_type === 'SUB ITA') langLabel = 'SUB';
         else if (v.language_type === 'CR ITA') langLabel = 'CR';
 
-        let titleStream = `${capitalize(baseName)} ▪ ${langLabel} ▪ S${sNum}`;
-        if (episodeNumber) titleStream += `E${episodeNumber}`;
+        let titleStream = `${capitalize(baseName)} ▪ ${langLabel}`;
+        const epTag = episodeTag(seasonNumber, episodeNumber);
+        if (epTag) titleStream += ` ▪ ${epTag}`;
 
         return { title: titleStream, url: finalUrl, behaviorHints: streamOut.behaviorHints } as StreamForStremio;
       } catch (e) {
@@ -1559,12 +1539,10 @@ export class AnimeWorldProvider {
           }
           const mp4 = streamData?.mp4_url;
           if (!mp4) continue;
-          const lang = isItaSlug(slug) ? 'Italian' : 'Original';
-          const sNum = seasonNumber || 1;
-          let baseName = (r.name || slug || normalizedTitle).toString().trim();
-          if (baseName.includes('\n')) baseName = baseName.replace(/\s+/g,' ').trim();
-          let titleStream = `${baseName} ▪ ${lang === 'Original' ? 'SUB' : 'ITA'} ▪ S${sNum}`;
-          if (episodeNumber) titleStream += `E${episodeNumber}`;
+          const baseName = animeWorldDisplayName(r.name, slug, normalizedTitle);
+          let titleStream = `${capitalize(baseName)} ▪ ${isItaSlug(slug) ? 'ITA' : 'SUB'}`;
+          const epTag = episodeTag(seasonNumber, episodeNumber);
+          if (epTag) titleStream += ` ▪ ${epTag}`;
           const streamOut = buildAnimeWorldStreamOutput(mp4, slug, this.config, { bingeGroup: 'animeworld-fallback' });
           streams.push({ title: titleStream, url: streamOut.url, behaviorHints: streamOut.behaviorHints });
         } catch (e) {
@@ -1585,6 +1563,38 @@ export function isItaSlug(slugOrName: string): boolean {
   const base = String(slugOrName || '').split('.')[0].toLowerCase();
   if (/(?:^|[-_])sub[-_]?ita$/.test(base)) return false;
   return /(?:^|[-_])(?:ita|cr[-_]?ita|ita[-_]?cr)$/.test(base);
+}
+
+/**
+ * Nome da mostrare in etichetta. La ricerca di AnimeWorld stampa due <a> per scheda
+ * (prima il poster coi soli badge, poi il titolo vero) e la deduplica tiene il primo:
+ * il `name` che arriva qui e' spesso vuoto, un badge di lingua ("DUB") o lo slug nudo.
+ * Non si puo' sistemare in awSearch: un name vuoto e' il segnale su cui si regge
+ * AdjustEmptyName, che corregge in SUB ITA gli slug base che il LangProbe sbaglia.
+ */
+export function animeWorldDisplayName(name: string | undefined, slug: string, fallback = ''): string {
+  const clean = String(name || '')
+    .replace(/\r?\n+/g, ' ')
+    .replace(/\b(?:DUB|SUB|CR)\b/gi, '')
+    .replace(/\((?:ITA|CR)\)/gi, '')
+    .replace(/\b(?:ITA|Movie|Special)\b/gi, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+  const looksLikeSlug = /^[a-z0-9]+(?:[-_][a-z0-9]+)*(?:\.[A-Za-z0-9_-]+)?$/.test(clean) && !clean.includes(' ');
+  if (clean.length >= 3 && !looksLikeSlug) return clean;
+  const fromSlug = animeWorldSlugBase(slug).replace(/[^a-z0-9]+/gi, ' ').trim();
+  return fromSlug || String(fallback || '').trim() || slug;
+}
+
+/**
+ * Etichetta S/E. La stagione si stampa solo quando e' davvero nota: negli id Kitsu ogni
+ * stagione e' un anime a se', quindi il campo season vale sempre 1 e stamparlo mette "S1"
+ * su episodi di S2. Per IMDB/TMDB la stagione e' reale e resta.
+ */
+export function episodeTag(seasonNumber: number | null, episodeNumber: number | null): string {
+  const s = seasonNumber != null ? `S${seasonNumber}` : '';
+  const e = episodeNumber != null ? `E${episodeNumber}` : '';
+  return `${s}${e}`;
 }
 
 /** Slug senza id random finale e senza suffisso di lingua: identifica l'opera, non la versione. */

--- a/src/providers/animeworld-provider.ts
+++ b/src/providers/animeworld-provider.ts
@@ -359,17 +359,34 @@ async function awSearch(query: string, date?: string): Promise<AnimeWorldResult[
       continue;
     }
     const $ = cheerio.load(String(html || ''));
+    const bySlug = new Map<string, AnimeWorldResult>();
     $('a[href*="/play/"]').each((_, el) => {
       const href = String($(el).attr('href') || '').trim();
       const path = normalizeAnimeWorldPath(href);
       if (!path || !path.startsWith('/play/')) return;
       const slug = path.replace('/play/', '');
-      if (!slug || seen.has(slug)) return;
+      if (!slug) return;
+      // Ogni scheda compare due volte: prima <a class="poster"> (nessun titolo, il testo
+      // sono i badge tipo "DUB") e poi <a class="name"> col titolo vero. Il primo definisce
+      // l'ordine di rilevanza, il secondo il titolo: teniamo entrambi.
+      const jtitle = String($(el).attr('data-jtitle') || '').replace(/\s+/g, ' ').trim();
+      const titleAttr = String($(el).attr('title') || '').replace(/\s+/g, ' ').trim();
+      const text = String($(el).text() || '').replace(/\s+/g, ' ').trim();
+      // Solo l'anchor col titolo espone data-jtitle; il testo del poster sono i badge
+      // ("DUB"), non un titolo, quindi non va preso come searchTitle.
+      const searchTitle = jtitle ? text : '';
+      const existing = bySlug.get(slug);
+      if (existing) {
+        if (searchTitle && !existing.searchTitle) existing.searchTitle = searchTitle;
+        return;
+      }
+      // `name` resta identico a prima (primo anchor incontrato): vedi AnimeWorldResult.
+      const name = String(jtitle || titleAttr || text || slug).replace(/\s+/g, ' ').trim();
+      const entry: AnimeWorldResult = { id: slug, slug, name, episodes_count: 0, language_type: 'SUB ITA' };
+      if (searchTitle) entry.searchTitle = searchTitle;
+      bySlug.set(slug, entry);
       seen.add(slug);
-      const name = String($(el).attr('data-jtitle') || $(el).attr('title') || $(el).text() || slug)
-        .replace(/\s+/g, ' ')
-        .trim();
-      out.push({ id: slug, slug, name, episodes_count: 0, language_type: 'SUB ITA' });
+      out.push(entry);
     });
     if (out.length) break;
   }
@@ -1508,11 +1525,23 @@ export class AnimeWorldProvider {
       // spesso pure di un'altra parte della stagione. Ora la lingua viene dallo slug.
       // I candidati restano ancorati allo slug base del primo risultato, altrimenti senza
       // versione ITA si pescherebbe lo slug -ita di un anime completamente diverso.
-      const anchor = animeWorldSlugBase(results[0].slug || results[0].id || results[0].name);
-      const related = anchor
-        ? results.filter(r => animeWorldSlugBase(r.slug || r.id || r.name).startsWith(anchor))
-        : results;
-      console.log('[AnimeWorld][FallbackFilter] Anchor base:', anchor, 'correlati:', related.length, '/', results.length);
+      // Preferenza: il titolo mostrato nei risultati, che e' nella stessa lingua della query
+      // (a meno del marcatore "(ITA)"). Gli slug non bastano: AnimeWorld nomina la stessa
+      // parte in modi diversi per SUB e ITA (…-2nd-season-part-2 contro …-2-part-2-ita),
+      // quindi un confronto per prefisso di slug perde la versione ITA.
+      const wanted = normalizeSearchTitleKey(normalizedTitle);
+      let related = results.filter(r => r.searchTitle && normalizeSearchTitleKey(r.searchTitle) === wanted);
+      if (related.length) {
+        console.log('[AnimeWorld][FallbackFilter] Match per titolo:', wanted, '->', related.length, '/', results.length);
+      } else {
+        // Nessun titolo utile (markup cambiato, o titolo diverso dalla query): ripiego
+        // sull'ancora dello slug del primo risultato, che segue la rilevanza della ricerca.
+        const anchor = animeWorldSlugBase(results[0].slug || results[0].id || results[0].name);
+        related = anchor
+          ? results.filter(r => animeWorldSlugBase(r.slug || r.id || r.name).startsWith(anchor))
+          : results;
+        console.log('[AnimeWorld][FallbackFilter] Nessun match per titolo, anchor base:', anchor, '->', related.length, '/', results.length);
+      }
       const picked = [
         ...related.filter(r => isItaSlug(r.slug || r.id || r.name)).slice(0, 1),
         ...related.filter(r => !isItaSlug(r.slug || r.id || r.name)).slice(0, 1),
@@ -1539,7 +1568,7 @@ export class AnimeWorldProvider {
           }
           const mp4 = streamData?.mp4_url;
           if (!mp4) continue;
-          const baseName = animeWorldDisplayName(r.name, slug, normalizedTitle);
+          const baseName = animeWorldDisplayName(r.searchTitle || r.name, slug, normalizedTitle);
           let titleStream = `${capitalize(baseName)} ▪ ${isItaSlug(slug) ? 'ITA' : 'SUB'}`;
           const epTag = episodeTag(seasonNumber, episodeNumber);
           if (epTag) titleStream += ` ▪ ${epTag}`;
@@ -1595,6 +1624,19 @@ export function episodeTag(seasonNumber: number | null, episodeNumber: number | 
   const s = seasonNumber != null ? `S${seasonNumber}` : '';
   const e = episodeNumber != null ? `E${episodeNumber}` : '';
   return `${s}${e}`;
+}
+
+/**
+ * Chiave di confronto fra il titolo cercato e quello mostrato nei risultati: via i marcatori
+ * di versione "(ITA)" / "(CR)" e la punteggiatura, cosi' "That Time I Got Reincarnated as a
+ * Slime 2 Part 2 (ITA)" e la query "…Slime 2 Part 2" collassano sulla stessa chiave.
+ */
+export function normalizeSearchTitleKey(title: string): string {
+  return String(title || '')
+    .replace(/\((?:ITA|CR|SUB\s*ITA)\)/gi, ' ')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
 }
 
 /** Slug senza id random finale e senza suffisso di lingua: identifica l'opera, non la versione. */

--- a/src/types/animeunity.ts
+++ b/src/types/animeunity.ts
@@ -85,6 +85,11 @@ export interface AnimeWorldResult {
   name: string;
   episodes_count: number;
   language_type?: string; // inferred (ITA, SUB ITA, CR ITA, ORIGINAL)
+  // Titolo mostrato nei risultati di ricerca (<a class="name">), es.
+  // "That Time I Got Reincarnated as a Slime 2 Part 2 (ITA)". Tenuto separato da `name`:
+  // quest'ultimo resta com'e' perche' un name vuoto e' il segnale su cui si regge
+  // AdjustEmptyName nella classificazione di lingua.
+  searchTitle?: string;
 }
 
 export interface AnimeWorldEpisode {


### PR DESCRIPTION
## Il problema

Su AnimeWorld il fallback `filter?year=` etichettava le versioni **in base alla posizione** nei risultati di ricerca: indice 0 = Original/SUB, indice 1 = Italian/ITA. Quando la ricerca restituisce due risultati SUB in cima, il secondo veniva servito come ITA pur essendo in giapponese — e spesso apparteneva a un'altra parte della stagione, quindi anche l'episodio era sbagliato.

Caso reale, `kitsu:42196:1:5` (That Time I Got Reincarnated as a Slime, stagione 2, episodio 5). Lo strict base filter azzera i risultati perché il titolo inglese non combacia con gli slug romaji, si passa al fallback, e i primi due risultati sono:

```
1. tensei-shitara-slime-datta-ken-2.jregU                 SUB, parte 1
2. tensei-shitara-slime-datta-ken-2nd-season-part-2.0K6vE SUB, parte 2   <- marcato ITA
3. tensei-shitara-slime-datta-ken-2-ita.27Bbg             ITA, parte 1   <- mai raggiunto
4. tensei-shitara-slime-datta-ken-2-part-2-ita.8pz6C      ITA, parte 2   <- mai raggiunto
```

Lo stream marcato ITA era il #2: episodio 5 richiesto → **episodio 17, in giapponese**.

## La soluzione

La lingua si deduce dal suffisso dello slug (`-ita` / `-cr-ita` / `-ita-cr`), come fa già il percorso normale con `language_type`, e si prende una versione ITA più una SUB.

Per selezionare i candidati si usa il titolo esposto dalla ricerca (`<a class=\"name\">`), che è nella stessa lingua della query a meno del marcatore `(ITA)`. Gli slug da soli non bastano: AnimeWorld nomina la stessa parte in modo diverso a seconda della lingua — `…-2nd-season-part-2` (SUB) contro `…-2-part-2-ita` (ITA) — quindi un confronto per prefisso perde la versione ITA delle stagioni divise in parti. Se il titolo manca o non combacia si ripiega sull'ancora dello slug del primo risultato.

Il titolo finisce in un campo nuovo `searchTitle`: **`name` resta identico a prima**, perché un `name` vuoto è il segnale su cui si regge `AdjustEmptyName`, che riporta a SUB ITA gli slug base che il `LangProbe` classifica ITA per errore (fra cui proprio `tensei-shitara-slime-datta-ken-2.jregU`, che è in giapponese). Popolare `name` alla fonte reintrodurrebbe lo stesso bug nel percorso normale.

## Etichette

Due correzioni cosmetiche incluse, allineate nei tre punti che compongono l'etichetta (mapping, ricerca normale, fallback):

- **Stagione**: negli id Kitsu ogni stagione è un anime separato, quindi il campo season vale sempre 1 e veniva stampato `S1E5` su episodi di stagione 2. Ora la stagione compare solo quando è nota davvero, cioè per IMDB/TMDB. Il parametro passato al mapping non serviva: `resolveLookupRequest` lo scarta già per i lookup Kitsu (`mapping-api.ts:169`).
- **Nome**: la ricerca stampa due `<a>` per scheda e la deduplica teneva il poster, che ha come testo i badge — da lì etichette tipo `DUB` o lo slug nudo.

## Verifica

Provato su un'istanza reale, confrontando il file mp4 effettivamente servito:

| richiesta | ITA | SUB |
|---|---|---|
| `kitsu:41024:1:5` (S1) | `…Ken_Ep_05_ITA.mp4` | `…Ken_Ep_05_SUB_ITA.mp4` |
| `kitsu:42196:1:5` (S2 p1) | `…Ken2_Ep_05_ITA.mp4` | `…Ken2_Ep_05_SUB_ITA.mp4` |
| `kitsu:43361:1:5` (S2 p2) | `…Ken2Part2_Ep_05_ITA.mp4` | `…Ken2Part2_Ep_05_SUB_ITA.mp4` |
| `kitsu:43361:1:11` (S2 p2) | `…Ken2Part2_Ep_11_ITA.mp4` | `…Ken2Part2_Ep_11_SUB_ITA.mp4` |

Prima della patch `kitsu:43361` restituiva il solo SUB e `kitsu:42196` serviva la parte 2 in giapponese sotto etichetta ITA.

Regressione IMDB verificata: `tt2560140:2:5` continua a rispondere `L attacco dei giganti ▪ S2E5`, la stagione resta dove è reale.