### PR TITLE
fix: update anime mapping API endpoint

### DIFF
--- a/config/provider_urls.json
+++ b/config/provider_urls.json
@@ -6,5 +6,5 @@
   "guardahd": "https://guardahd.stream",
   "guardaserie": "https://guardaserietv.autos",
   "guardoserie": "https://guardoserie.space",
-  "mapping_api": "https://animemapping.stremio-italia.eu"
+  "mapping_api": "https://animemapping.realbestia.com"
 }


### PR DESCRIPTION
Updates the Anime Mapping API base URL used by provider resolution.

The previous endpoint:
https://animemapping.stremio-italia.eu

currently returns 502 Bad Gateway.

The replacement endpoint:
https://animemapping.realbestia.com

is the current mapping service used by recent realbestia1 projects and returns
the expected mapping for kitsu:50701 (My Hero Academia: I am a hero too),
including the correct AnimeWorld target.

This is intentionally a minimal change limited to config/provider_urls.json.
No fallback or matching logic is modified.